### PR TITLE
Fixes for Testing branch

### DIFF
--- a/AsyncAccess/src/dashboard/components/UserProfile.jsx
+++ b/AsyncAccess/src/dashboard/components/UserProfile.jsx
@@ -10,6 +10,7 @@ import CancelIcon from '@mui/icons-material/Cancel';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import PhotoCamera from '@mui/icons-material/PhotoCamera';
 import { getCurrentUserProfile, updateUserProfile } from '../../services/userService';
+import authService from '../../services/authService';  // Import authService
 
 const VITE_BACKEND_SERVER_URL = import.meta.env.VITE_BACKEND_SERVER_URL;
 
@@ -25,6 +26,7 @@ export default function UserProfile() {
   const [profilePictureFile, setProfilePictureFile] = useState(null);
   const [profilePicturePreview, setProfilePicturePreview] = useState(null);
   const fileInputRef = useRef(null);
+  const handleAuthError = authService.useAuthRedirect(); // Use the hook here
 
   const fetchUser = async () => {
     setIsLoading(true);
@@ -34,7 +36,7 @@ export default function UserProfile() {
       setError('');
     } catch (err) {
       setError(err.message || 'Failed to fetch user data.');
-      console.error(err);
+      handleAuthError(err); // Call the hook to handle potential auth errors
     } finally {
       setIsLoading(false);
     }
@@ -68,7 +70,7 @@ export default function UserProfile() {
       setEditingField(null);
     } catch (err) {
       setError(err.message || `Failed to update ${field}.`);
-      console.error(err);
+      handleAuthError(err);
     } finally {
       setIsLoading(false);
     }
@@ -96,7 +98,7 @@ export default function UserProfile() {
       setProfilePictureFile(null);
       setProfilePicturePreview(null);
     } catch (err) {
-      setError(err.message || 'Failed to upload profile picture.');
+      setError(err.message || 'Failed to upload profile picture.');      handleAuthError(err);
       console.error(err);
     } finally {
       setIsLoading(false);
@@ -114,7 +116,7 @@ export default function UserProfile() {
       setProfilePictureFile(null);
       setProfilePicturePreview(null);
     } catch (err) {
-      setError(err.message || 'Failed to remove profile picture.');
+      setError(err.message || 'Failed to remove profile picture.');      handleAuthError(err);
       console.error(err);
     } finally {
       setIsLoading(false);

--- a/AsyncAccess/src/home-page/components/AsyncAccessIcon.jsx
+++ b/AsyncAccess/src/home-page/components/AsyncAccessIcon.jsx
@@ -13,7 +13,14 @@ export default function AsyncAccessIcon() {
   const accessPart = "Access";
 
   const textColor = "#4876EE"; // Blue color for "Access"
-  const asyncColor = theme.palette.mode === 'light' ? "#FFFFFF" : "#000000"; // White for dark, Black for light
+  const asyncColor = theme.palette.mode === 'light' ? theme.palette.primary.light : theme.palette.primary.main;
+  // theme.applyStyles('dark', {
+  //   color: 'primary.light',
+  // }),
+  // color: 'primary.main',
+  // ...theme.applyStyles('dark', {
+  //   color: 'primary.light',
+  // }),
 
   const newViewBoxWidth = 115;
   const svgInternalWidth = newViewBoxWidth;

--- a/AsyncAccess/src/services/authService.js
+++ b/AsyncAccess/src/services/authService.js
@@ -71,20 +71,18 @@ export const updateUserProfilePicture = async (file) => {
   }
 };
 
-
 const useAuthRedirect = () => {
-    const navigate = useNavigate();
-    return (error) => {
-      if (error.response && (error.response.status === 401 || error.response.status === 403)) {
-        const redirectPath = error.response.status === 401 ? '/unauthenticated' : '/unauthorized';
-        console.warn(`Received ${error.response.status} from API. Redirecting to ${redirectPath}`);
-        navigate(redirectPath, { replace: true });
-        // We need to throw an error here so the components know that the request failed
-        throw new Error(`Redirecting to ${redirectPath}`);
-      }
-      // Re-throw other errors for component-level handling if necessary.
-      throw error;
-    };
+  const navigate = useNavigate();
+  return (error) => {
+    if (error.response && (error.response.status === 401 || error.response.status === 403)) {
+      const redirectPath = error.response.status === 401 ? '/unauthenticated' : '/unauthorized';
+      console.warn(`Received ${error.response.status} from API. Redirecting to ${redirectPath}`);
+      navigate(redirectPath, { replace: true });
+      return; // Stop further execution after redirect
+    }
+    // Re-throw other errors for component-level handling if necessary.
+    throw error;
+  };
 };
 
 export { apiClientInstance as apiClient };

--- a/AsyncAccess/src/services/userService.js
+++ b/AsyncAccess/src/services/userService.js
@@ -1,18 +1,17 @@
 import { apiClient } from './authService'; // Assuming apiClient is exported from authService.js
-import authService from './authService';
 
 /**
  * Fetches the current logged-in user's profile information.
  * @returns {Promise<Object>} A promise that resolves to the user object.
  */
 export const getCurrentUserProfile = async () => {
-    const handleAuthError = authService.useAuthRedirect();
-    try {
-        const response = await apiClient.get('/users/profile');
-        return response.data;
-    } catch (error) {
-        throw handleAuthError(error); // Use the redirection handling function
-    }
+  try {
+    const response = await apiClient.get('/users/profile');
+    return response.data;
+  } catch (error) {
+    // We don't handle the redirect here anymore; it will be handled in the component.
+    throw error;
+  }
 };
 
 /**


### PR DESCRIPTION
This pull request introduces improvements to error handling and styling in the `AsyncAccess` project. The key changes include integrating a new `useAuthRedirect` hook for centralized authentication error handling in the `UserProfile` component, refining the color logic in the `AsyncAccessIcon` component, and simplifying the `authService` logic.

### Error Handling Enhancements:
* `AsyncAccess/src/dashboard/components/UserProfile.jsx`:
  - Integrated the `useAuthRedirect` hook from `authService` to handle authentication errors consistently across multiple functions (`fetchUser`, `updateField`, `uploadProfilePicture`, and `removeProfilePicture`). This replaces direct error logging with redirection logic. [[1]](diffhunk://#diff-8881c1c3ceffe32838a685f198fddd9e96d456f11a92735e48274ce7b728c3d6R29) [[2]](diffhunk://#diff-8881c1c3ceffe32838a685f198fddd9e96d456f11a92735e48274ce7b728c3d6L37-R39) [[3]](diffhunk://#diff-8881c1c3ceffe32838a685f198fddd9e96d456f11a92735e48274ce7b728c3d6L71-R73) [[4]](diffhunk://#diff-8881c1c3ceffe32838a685f198fddd9e96d456f11a92735e48274ce7b728c3d6L99-R101) [[5]](diffhunk://#diff-8881c1c3ceffe32838a685f198fddd9e96d456f11a92735e48274ce7b728c3d6L117-R119)

* `AsyncAccess/src/services/authService.js`:
  - Updated the `useAuthRedirect` function to stop execution after a redirect instead of throwing an error, simplifying its behavior.

* `AsyncAccess/src/services/userService.js`:
  - Removed the `useAuthRedirect` call from the `getCurrentUserProfile` function, delegating redirection handling to the component level for better separation of concerns.

### Styling Improvements:
* `AsyncAccess/src/home-page/components/AsyncAccessIcon.jsx`:
  - Updated the color logic for the `asyncColor` variable to use `theme.palette.primary` values, ensuring a consistent design across light and dark modes.